### PR TITLE
2 logic to swap out category archive with designated page

### DIFF
--- a/archive-pages.php
+++ b/archive-pages.php
@@ -30,6 +30,7 @@ function archive_pages_render_settings_page() {
 		<h1><?php echo get_admin_page_title(); ?></h1>
 		<form action="options.php" method="post">
 				<?php
+				//do this once for post types, once for categories
 					settings_fields( 'archive_pages_settings' );
 					do_settings_sections( 'archive-pages' );
 				?>
@@ -44,35 +45,55 @@ function archive_pages_render_settings_page() {
  * Register plugin setting options.
  */
 function archive_pages_settings_init() {
-	// Get custom post types that have public archive pages.
-	$post_types = get_post_types(array(
-		'has_archive' => true,
-		'_builtin' 		=> false,
-	), 'objects');
 
-	/**
-	 * Register a section for our settings page.
-	 * Title & callback are blank because we don't want a section heading to show, but settings need a section to appear.
-	 */
-	add_settings_section('archive_pages_section', '', '', 'archive-pages');
+	//section for category archives
+	add_settings_section('category_pages_section', 'Category Archives', '', 'archive-pages');
 
-	// Add setting & dropdown for each post type.
-	foreach ($post_types as $post_type) {
-		// Register setting for this CPT.
-		register_setting('archive_pages_settings', 'archive_page_' . $post_type->name);
 
-		// Add field for this CPT.
+	//get categories
+	$categories = get_categories( array(
+		'orderby' => 'name',
+		'order'		=> 'ASC',
+		'hide_empty'	=> false
+	)); 
+
+	//loop through category archives
+	archive_pages_settings_fields( $categories, 'name', 'category_pages_section');
+
+	
+}
+add_action( 'admin_init', 'archive_pages_settings_init' );
+
+
+/**
+ * Loop through list of archives and output nice label
+ *
+ * @param $archives array - archive list of post types, categories, etc
+ * @param $label string - array key to use for label
+ * @param $section string - section to add fields to
+ * 
+ */
+function archive_pages_settings_fields( $archives, $label, $section ){
+	// Add setting & dropdown for each archive
+	foreach ($archives as $archive) {
+
+		//get a standard slug for the archive name
+		$field_slug = sanitize_title($archive->name);
+
+		// Register setting for this archive.
+		register_setting('archive_pages_settings', 'archive_page_' . $field_slug);
+
+		// Add field for this archive.
 		add_settings_field(
-			'archive_page_' . $post_type->name,
-			"{$post_type->label} ({$post_type->name})",
-			'archive_pages_wp_dropdown_pages',
-			'archive-pages',
-			'archive_pages_section',
-			array( 'name' => 'archive_page_' . $post_type->name )
+			'archive_page_' . $field_slug, 			//slug-name to identify field
+			$archive->$label, 									//title or label of field
+			'archive_pages_wp_dropdown_pages', 	//callback
+			'archive-pages',										//settings page
+			$section, 													//section of settings page
+			array( 'name' => 'archive_page_' . $field_slug )
 		);
 	}
 }
-add_action( 'admin_init', 'archive_pages_settings_init' );
 
 /**
  * Render list of all pages.
@@ -103,12 +124,17 @@ function archive_pages_filter_archive_titles($args) {
  * Override the `get_the_archive_title` function to display the title from the selected archive page.
  */
 function filter_archive_page_title( $title ) {
-	if ( is_post_type_archive() ) {
+
+	$archive_page = '';
+
+	if ( is_post_type_archive()  ) {
+
 		$archive_page = get_option('archive_page_' . get_query_var( 'post_type' ) );
 
-		if ( $archive_page ) {
-			return get_the_title ($archive_page );
-		}
+	}
+
+	if ( $archive_page ) {
+		return get_the_title ($archive_page );
 	}
 
 	return $title;
@@ -119,12 +145,17 @@ add_filter( 'get_the_archive_title', 'filter_archive_page_title', 10 );
  * Override the `get_the_archive_description` function to display the post content from the selected archive page.
  */
 function filter_archive_page_description( $description ) {
+
+	$archive_page = '';
+
 	if ( is_post_type_archive() ) {
 		$archive_page = get_option('archive_page_' . get_query_var( 'post_type' ) );
-
-		if ( $archive_page ) {
-			return get_the_content(null, false, $archive_page );
-		}
+	}
+	
+	if ( $archive_page ) {
+		
+		return get_the_content(null, false, $archive_page );
+		
 	}
 
 	return $description;


### PR DESCRIPTION
Hi Heather - I added the functionality for the category / landing page swaparoo. The plugin checks query_vars for a category name and if it thinks it's on a category archive it finds the assigned category page from the plugin settings screen and grabs the ID. If that page has been published, it modifies the request to load that specific page. 

Post type functionality is unchanged: on post type archive, title and description are included from the assigned page. 

Please test and lmk if this looks good to you. The functionality might not be needed on every site. Next idea is to enable/disable settings for various archive types (post type, category, custom taxonomy) 